### PR TITLE
fix: correct playerDeaths getter in createPlayerStats INSERT & DB Calculation with 1 Player

### DIFF
--- a/src/main/java/me/aymanisam/hungergames/handlers/GameSequenceHandler.java
+++ b/src/main/java/me/aymanisam/hungergames/handlers/GameSequenceHandler.java
@@ -407,7 +407,7 @@ public class GameSequenceHandler {
 		    if (startingPlayers != null && worldPlayerPlacements.size() == worldStartingPlayers.size()) {
 			    for (Player player : worldPlayerPlacements) {
 				    int playerIndex = worldPlayerPlacements.indexOf(player);
-				    double percentile = (1 - (playerIndex / (worldPlayerPlacements.size() - 1.0))) * 100.0;
+				    double percentile = worldPlayerPlacements.size() == 1 ? 100.0 : (1 - (playerIndex / (worldPlayerPlacements.size() - 1.0))) * 100.0;
 
                     if (configHandler.getPluginSettings().getBoolean("database.enabled")) {
 	                    PlayerStatsHandler playerStats = statsMap.get(player.getUniqueId());
@@ -423,7 +423,7 @@ public class GameSequenceHandler {
 		    if (worldTeamPlacements.size() == teams.computeIfAbsent(world.getName(), k -> new ArrayList<>()).size()) {
 			    for (List<Player> team : worldTeamPlacements) {
 				    int teamIndex = worldTeamPlacements.indexOf(team);
-				    double percentile = (1 - (teamIndex / (worldTeamPlacements.size() - 1.0))) * 100.0;
+				    double percentile = worldTeamPlacements.size() == 1 ? 100.0 : (1 - (teamIndex / (worldTeamPlacements.size() - 1.0))) * 100.0;
 
                     if (configHandler.getPluginSettings().getBoolean("database.enabled")) {
                         for (Player player : team) {

--- a/src/main/java/me/aymanisam/hungergames/stats/DatabaseHandler.java
+++ b/src/main/java/me/aymanisam/hungergames/stats/DatabaseHandler.java
@@ -154,7 +154,7 @@ public class DatabaseHandler {
         statement.setInt(13, stats.getSupplyDropsOpened());
         statement.setInt(14, stats.getEnvironmentDeaths());
         statement.setInt(15, stats.getBorderDeaths());
-        statement.setInt(16, stats.getBorderDeaths());
+        statement.setInt(16, stats.getPlayerDeaths());
         statement.setInt(17, stats.getArrowsShot());
         statement.setInt(18, stats.getArrowsLanded());
         statement.setInt(19, stats.getFireworksShot());


### PR DESCRIPTION
Parameter 16 was calling getBorderDeaths() instead of getPlayerDeaths(),
 causing playerDeaths to always be inserted as 0 for new players.
(The values end up being always correct anyways because update calls the correct parameter)